### PR TITLE
add support for Fast HTML Parser

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,3 +1,5 @@
+const EMPTY_OBJECT = {};
+
 function isTag(elem){
 	return elem.nodeType === 1;
 }
@@ -5,7 +7,7 @@ function getChildren(elem){
 	return elem.childNodes ? Array.prototype.slice.call(elem.childNodes, 0) : [];
 }
 function getParent(elem){
-	return elem.parentElement;
+	return elem.parentNode;
 }
 function removeSubsets(nodes) {
 	var idx = nodes.length, node, ancestor, replace;
@@ -48,23 +50,24 @@ var adapter = {
 	},
 	getSiblings: function(elem){
 		var parent = getParent(elem);
-		return parent && getChildren(parent);
+		return parent ? getChildren(parent) : [elem];
 	},
 	getChildren: getChildren,
 	getParent: getParent,
 	getAttributeValue: function(elem, name){
-		if(elem.attributes && elem.attributes[name]){
-			return elem.attributes[name].value;
+		if(elem.attributes && name in elem.attributes){
+			var attr = elem.attributes[name];
+			return typeof attr === "string" ? attr : attr.value;
 		} else if (name === "class" && elem.classList) {
 			return Array.from(elem.classList).join(" ");
 		}
 	},
 	hasAttrib: function(elem, name){
-		return name in elem.attributes;
+		return name in (elem.attributes || EMPTY_OBJECT);
 	},
 	removeSubsets: removeSubsets,
 	getName: function(elem){
-		return elem.tagName.toLowerCase();
+		return (elem.tagName || "").toLowerCase();
 	},
 	findOne: function findOne(test, arr){
 		var elem = null;


### PR DESCRIPTION
hey @nrkn 

i've made some small changes to support this fast and lightweight jsdom alternative: https://www.npmjs.com/package/node-html-parser

i'm using these modifications successfully in my project: https://github.com/leeoniya/dropcss

i'd prefer not to maintain my own fork or keep a modified copy in the `dropcss` repo, so if you merge these changes and publish to npm, i'll be able to simply use it as a dependency.

all the mocha tests still pass.

thanks for your work, too :)